### PR TITLE
Add support of python 'object' type

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -112,6 +112,13 @@ def test_dict():
         vol.Schema({})
     )
 
+    def string(x: str) -> str:
+        return x
+
+    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(vol.Schema({string: string}))
+    assert {"type": "object", "additionalProperties": True} == convert(vol.Schema(object))
+    assert {"type": "object", "additionalProperties": True} == convert(vol.Schema({string: object}))
+
 
 def test_tuple():
     assert {"type": "array", "items": {"type": "string"}} == convert(vol.Schema(tuple))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -115,9 +115,15 @@ def test_dict():
     def string(x: str) -> str:
         return x
 
-    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(vol.Schema({string: string}))
-    assert {"type": "object", "additionalProperties": True} == convert(vol.Schema(object))
-    assert {"type": "object", "additionalProperties": True} == convert(vol.Schema({string: object}))
+    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(
+        vol.Schema({string: string})
+    )
+    assert {"type": "object", "additionalProperties": True} == convert(
+        vol.Schema(object)
+    )
+    assert {"type": "object", "additionalProperties": True} == convert(
+        vol.Schema({string: object})
+    )
 
 
 def test_tuple():


### PR DESCRIPTION
Correctly handle schemas with python `object` type, such as `vol.Schema(object)` and `vol.Schema({string: object})`.