### PR TITLE
Add an explicit type for enums

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -50,17 +50,13 @@ def test_datetime():
 
 
 def test_in():
-    assert {
-        "type": "string",
-        "enum": ["beer", "wine"]
-    } == convert(vol.Schema(vol.In(["beer", "wine"])))
+    assert {"type": "string", "enum": ["beer", "wine"]} == convert(
+        vol.Schema(vol.In(["beer", "wine"]))
+    )
 
 
 def test_in_integer():
-    assert {
-        "type": "integer",
-        "enum": [1, 2]
-    } == convert(vol.Schema(vol.In([1, 2])))
+    assert {"type": "integer", "enum": [1, 2]} == convert(vol.Schema(vol.In([1, 2])))
 
 
 def test_in_dict():
@@ -407,14 +403,9 @@ def test_nested_in_list():
         "properties": {
             "drink": {
                 "type": "array",
-                "items": {
-                    "type": "string",
-                    "enum": ["beer", "wine"]
-                }
+                "items": {"type": "string", "enum": ["beer", "wine"]},
             },
         },
         "required": [],
         "type": "object",
-    } == convert(vol.Schema({
-        vol.Optional("drink"): [vol.In(["beer", "wine"])]
-    }))
+    } == convert(vol.Schema({vol.Optional("drink"): [vol.In(["beer", "wine"])]}))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -50,11 +50,22 @@ def test_datetime():
 
 
 def test_in():
-    assert {"enum": ["beer", "wine"]} == convert(vol.Schema(vol.In(["beer", "wine"])))
+    assert {
+        "type": "string",
+        "enum": ["beer", "wine"]
+    } == convert(vol.Schema(vol.In(["beer", "wine"])))
+
+
+def test_in_integer():
+    assert {
+        "type": "integer",
+        "enum": [1, 2]
+    } == convert(vol.Schema(vol.In([1, 2])))
 
 
 def test_in_dict():
     assert {
+        "type": "string",
         "enum": ["en_US", "zh_CN"],
     } == convert(
         vol.Schema(
@@ -389,3 +400,21 @@ def test_function():
     assert {"type": "object", "additionalProperties": {"type": "integer"}} == convert(
         validator_dict_int
     )
+
+
+def test_nested_in_list():
+    assert {
+        "properties": {
+            "drink": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["beer", "wine"]
+                }
+            },
+        },
+        "required": [],
+        "type": "object",
+    } == convert(vol.Schema({
+        vol.Optional("drink"): [vol.In(["beer", "wine"])]
+    }))

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -25,9 +25,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
 
     def ensure_default(value: dict[str:Any]):
         """Make sure that type is set."""
-        if all(
-            x not in value for x in ("type", "anyOf", "oneOf", "allOf", "not")
-        ):
+        if all(x not in value for x in ("type", "anyOf", "oneOf", "allOf", "not")):
             value["type"] = "string"  # Type not determined, using default
         return value
 

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -26,7 +26,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
     def ensure_default(value: dict[str:Any]):
         """Make sure that type is set."""
         if all(
-            x not in value for x in ("type", "enum", "anyOf", "oneOf", "allOf", "not")
+            x not in value for x in ("type", "anyOf", "oneOf", "allOf", "not")
         ):
             value["type"] = "string"  # Type not determined, using default
         return value

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -152,8 +152,16 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
 
     if isinstance(schema, vol.In):
         if isinstance(schema.container, Mapping):
-            return {"enum": list(schema.container.keys())}
-        return {"enum": schema.container}
+            enum_values = list(schema.container.keys())
+        else:
+            enum_values = schema.container
+        # Infer the enum type based on the type of the first value, but default
+        # to a string as a fallback.
+        if enum_values:
+            enum_type = TYPES_MAP.get(type(enum_values[0]), "string")
+        else:
+            enum_type = "string"
+        return {"type": enum_type, "enum": enum_values}
 
     if schema in (vol.Lower, vol.Upper, vol.Capitalize, vol.Title, vol.Strip):
         return {


### PR DESCRIPTION
Add an explicit `type` field when creating enums. Adds a test for a few cases including a compound case of multiple types. 
 This is required by Google Generative API which enforces a `type` field is presenting when using type enum.