### PR TITLE
Collapse AllOf and AnyOf keys

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -269,8 +269,12 @@ def test_any_of():
         vol.Any(float, int)
     )
 
-    assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(vol.Any(float, int, float, int, int))
-    assert {"type": "object", "additionalProperties": True} == convert(vol.Any(float, int, object))
+    assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(
+        vol.Any(float, int, float, int, int)
+    )
+    assert {"type": "object", "additionalProperties": True} == convert(
+        vol.Any(float, int, object)
+    )
 
 
 def test_all_of():
@@ -279,7 +283,9 @@ def test_all_of():
     )
 
     assert {"type": "string"} == convert(vol.All(object, str))
-    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(vol.All(object, {str: str}))
+    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(
+        vol.All(object, {str: str})
+    )
 
 
 def test_key_any():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -269,11 +269,17 @@ def test_any_of():
         vol.Any(float, int)
     )
 
+    assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(vol.Any(float, int, float, int, int))
+    assert {"type": "object", "additionalProperties": True} == convert(vol.Any(float, int, object))
+
 
 def test_all_of():
     assert {"allOf": [{"minimum": 5}, {"minimum": 10}]} == convert(
         vol.All(vol.Range(min=5), vol.Range(min=10))
     )
+
+    assert {"type": "string"} == convert(vol.All(object, str))
+    assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(vol.All(object, {str: str}))
 
 
 def test_key_any():

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -107,7 +107,11 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
         allOf = []
         for validator in schema.validators:
             v = convert(validator, custom_serializer=custom_serializer)
-            if not v or v in allOf or v == {"type": "object", "additionalProperties": True}:
+            if (
+                not v
+                or v in allOf
+                or v == {"type": "object", "additionalProperties": True}
+            ):
                 continue
             if v.keys() & val.keys():
                 # Some of the keys are intersecting - fallback to allOf
@@ -175,22 +179,26 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
         if len(schema) == 1:
             result = convert(schema[0], custom_serializer=custom_serializer)
         else:
-            anyOf = [convert(val, custom_serializer=custom_serializer) for val in schema]
-            if {'type': 'object', 'additionalProperties': True} in anyOf:
-                result = {'type': 'object', 'additionalProperties': True}
+            anyOf = [
+                convert(val, custom_serializer=custom_serializer) for val in schema
+            ]
+            if {"type": "object", "additionalProperties": True} in anyOf:
+                result = {"type": "object", "additionalProperties": True}
             else:
                 tmpAnyOf = []
                 for item in anyOf:
-                    if item in tmpAnyOf:  #Remove duplicated items
+                    if item in tmpAnyOf:  # Remove duplicated items
                         continue
                     tmpItem = item.copy()
-                    if item.get("nullable"):  #Merge "nullable" property into an existing item
+                    if item.get(
+                        "nullable"
+                    ):  # Merge "nullable" property into an existing item
                         tmpItem.pop("nullable")
                         if tmpItem in tmpAnyOf:
                             tmpAnyOf[tmpAnyOf.index(tmpItem)]["nullable"] = True
                             continue
                     tmpItem["nullable"] = True
-                    if tmpItem in tmpAnyOf:  #Ignore duplicated items that are nullable
+                    if tmpItem in tmpAnyOf:  # Ignore duplicated items that are nullable
                         continue
                     tmpAnyOf.append(item)
 

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -107,7 +107,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
         allOf = []
         for validator in schema.validators:
             v = convert(validator, custom_serializer=custom_serializer)
-            if not v:
+            if not v or v in allOf or v == {"type": "object", "additionalProperties": True}:
                 continue
             if v.keys() & val.keys():
                 # Some of the keys are intersecting - fallback to allOf
@@ -175,11 +175,29 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
         if len(schema) == 1:
             result = convert(schema[0], custom_serializer=custom_serializer)
         else:
-            result = {
-                "anyOf": [
-                    convert(val, custom_serializer=custom_serializer) for val in schema
-                ]
-            }
+            anyOf = [convert(val, custom_serializer=custom_serializer) for val in schema]
+            if {'type': 'object', 'additionalProperties': True} in anyOf:
+                result = {'type': 'object', 'additionalProperties': True}
+            else:
+                tmpAnyOf = []
+                for item in anyOf:
+                    if item in tmpAnyOf:  #Remove duplicated items
+                        continue
+                    tmpItem = item.copy()
+                    if item.get("nullable"):  #Merge "nullable" property into an existing item
+                        tmpItem.pop("nullable")
+                        if tmpItem in tmpAnyOf:
+                            tmpAnyOf[tmpAnyOf.index(tmpItem)]["nullable"] = True
+                            continue
+                    tmpItem["nullable"] = True
+                    if tmpItem in tmpAnyOf:  #Ignore duplicated items that are nullable
+                        continue
+                    tmpAnyOf.append(item)
+
+                if len(tmpAnyOf) == 1:
+                    result = tmpAnyOf[0]
+                else:
+                    result = {"anyOf": tmpAnyOf}
         if nullable:
             result["nullable"] = True
         return result
@@ -252,6 +270,6 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
             else:
                 return {}
 
-        return convert(schema, custom_serializer=custom_serializer)
+        return ensure_default(convert(schema, custom_serializer=custom_serializer))
 
     raise ValueError("Unable to convert schema: {}".format(schema))


### PR DESCRIPTION
This PR aims to collapse elements of `AllOf` and `AnyOf` keys to reduce duplication and produce a shorter form whenever it is possible.

Example:

`{"AnyOf": [{"type": "string"}, {"type": "string"}]}` -> `{"type": "string"}`
```
{"AllOf": [
  {"type": "object", "additionalProperties": True},
  {"type": "object", "properties": {"name": {"type": "string"}}}
]}
```
->  `{"type": "object", "properties": {"name": {"type": "string"}}}`