### PR TITLE
Fix Any key if wrapped in Marker

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -318,6 +318,24 @@ def test_key_any():
         )
     )
 
+    assert {
+        "properties": {
+            "conversation_command": {"type": "string"},
+            "hours": {"type": "integer"},
+            "minutes": {"type": "integer"},
+            "name": {"type": "string"},
+            "seconds": {"type": "integer"},
+        },
+        "required": [],
+        "type": "object",
+    } == convert(
+        {
+            vol.Required(vol.Any("hours", "minutes", "seconds")): int,
+            vol.Optional("name"): str,
+            vol.Optional("conversation_command"): str,
+        }
+    )
+
 
 def test_function():
     def validator(data):

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -69,8 +69,8 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
 
             pval = ensure_default(pval)
 
-            if isinstance(key, vol.Any):
-                for val in key.validators:
+            if isinstance(pkey, vol.Any):
+                for val in pkey.validators:
                     if isinstance(val, vol.Marker):
                         if val.description:
                             properties[str(val.schema)] = pval.copy()
@@ -88,7 +88,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
                 if additional_properties is None:
                     additional_properties = pval
 
-            if isinstance(key, vol.Required):
+            if isinstance(key, vol.Required) and not isinstance(pkey, vol.Any):
                 required.append(str(pkey))
 
         val = {"type": "object"}


### PR DESCRIPTION
Fix handling schemas like `{vol.Optional(vol.Any("apples", "oranges")): int}`