### PR TITLE
Set default type to number if vol.Range is used

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -279,6 +279,7 @@ def test_any_of():
     assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(
         vol.Any(float, int, float, int, int)
     )
+
     assert {"type": "object", "additionalProperties": True} == convert(
         vol.Any(float, int, object)
     )
@@ -290,8 +291,13 @@ def test_all_of():
     )
 
     assert {"type": "string"} == convert(vol.All(object, str))
+
     assert {"type": "object", "additionalProperties": {"type": "string"}} == convert(
         vol.All(object, {str: str})
+    )
+
+    assert {"maximum": 10, "minimum": 5, "type": "number"} == convert(
+        vol.All(vol.Range(min=5), vol.Range(max=10))
     )
 
 

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -26,7 +26,13 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
     def ensure_default(value: dict[str:Any]):
         """Make sure that type is set."""
         if all(x not in value for x in ("type", "anyOf", "oneOf", "allOf", "not")):
-            value["type"] = "string"  # Type not determined, using default
+            if any(
+                x in value
+                for x in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum")
+            ):
+                value["type"] = "number"
+            else:
+                value["type"] = "string"
         return value
 
     additional_properties = None


### PR DESCRIPTION
If the schema does not contain a type, but `vol.Range` is used, assume the type in "number" and not "string".
Example: `vol.Schema(vol.Range(min=10))`