### PR TITLE
Remove excessive nullables in AnyOf

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -322,6 +322,8 @@ def test_any_of():
         )
     )
 
+    assert {"anyOf": [{"type": "number"}, {"type": "integer"}], "nullable": True} == convert(vol.Any(vol.Maybe(float), vol.Maybe(int)))
+
 
 def test_all_of():
     assert {"allOf": [{"minimum": 5}, {"minimum": 10}]} == convert(

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -254,6 +254,27 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
                     tmpAnyOf.append(item)
                 anyOf = tmpAnyOf
 
+                # Remove excessive nullables
+                null_count = 0
+                if not nullable:
+                    for item in anyOf:
+                        if item.get("nullable") is True:
+                            null_count = null_count + 1
+                        if null_count > 1:
+                            break
+
+                if nullable or null_count > 1:
+                    nullable = True
+                    tmpAnyOf = []
+                    for item in anyOf:
+                        if not "nullable" in item:
+                            tmpAnyOf.append(item)
+                            continue
+                        tmpItem = item.copy()
+                        tmpItem.pop("nullable")
+                        tmpAnyOf.append(tmpItem)
+                    anyOf=tmpAnyOf
+
                 if len(anyOf) == 1:
                     result = anyOf[0]
                 else:


### PR DESCRIPTION
Example:

```json
{"anyOf": [{"type": "integer", "nullable": true}, {"type": "number", "nullable": true}]}
```

becomes

```json
{"anyOf": [{"type": "integer"}, {"type": "number"}], "nullable": true}
```