### PR TITLE
Add field description to the output voluptuous schema

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -579,3 +579,35 @@ def test_mixed_type_list() -> None:
 
     with pytest.raises(vol.Invalid):
         validator(123)
+
+
+@pytest.mark.parametrize(
+    "required",
+    [
+        (["query"]),
+        ([]),
+    ]
+)
+def test_convert_to_voluptuous_marker_description(required: list[str]):
+    schema = convert_to_voluptuous({
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The query to search for"
+            },
+            "max_results": {
+                "type": "number",
+                "description": "The maximum number of results to return",
+            }
+        },
+        "required": required,
+    })
+    # keys = list(schema.schema.keys())
+    assert [
+        (key, key.description)
+        for key in schema.schema.keys()
+    ] == [
+        ("query", "The query to search for"),
+        ("max_results", "The maximum number of results to return")
+    ]

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -586,28 +586,24 @@ def test_mixed_type_list() -> None:
     [
         (["query"]),
         ([]),
-    ]
+    ],
 )
 def test_convert_to_voluptuous_marker_description(required: list[str]):
-    schema = convert_to_voluptuous({
-        "type": "object",
-        "properties": {
-            "query": {
-                "type": "string",
-                "description": "The query to search for"
+    schema = convert_to_voluptuous(
+        {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The query to search for"},
+                "max_results": {
+                    "type": "number",
+                    "description": "The maximum number of results to return",
+                },
             },
-            "max_results": {
-                "type": "number",
-                "description": "The maximum number of results to return",
-            }
-        },
-        "required": required,
-    })
+            "required": required,
+        }
+    )
     # keys = list(schema.schema.keys())
-    assert [
-        (key, key.description)
-        for key in schema.schema.keys()
-    ] == [
+    assert [(key, key.description) for key in schema.schema.keys()] == [
         ("query", "The query to search for"),
-        ("max_results", "The maximum number of results to return")
+        ("max_results", "The maximum number of results to return"),
     ]

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -602,7 +602,6 @@ def test_convert_to_voluptuous_marker_description(required: list[str]):
             "required": required,
         }
     )
-    # keys = list(schema.schema.keys())
     assert [(key, key.description) for key in schema.schema.keys()] == [
         ("query", "The query to search for"),
         ("max_results", "The maximum number of results to return"),

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -429,11 +429,14 @@ def convert_to_voluptuous(schema: dict) -> vol.Schema:
         required_properties = set(schema.get("required", []))
         for key, value in schema.get("properties", {}).items():
             value_type = convert_to_voluptuous(value)
+            description: str | None = None
+            if isinstance(value, dict):
+                description = value.get("description")
             if key in required_properties:
                 key_type = vol.Required
             else:
                 key_type = vol.Optional
-            properties[key_type(key)] = value_type
+            properties[key_type(key, description=description)] = value_type
         if schema.get("additionalProperties") is True:
             return vol.Schema(properties, extra=vol.ALLOW_EXTRA)
         return vol.Schema(properties)


### PR DESCRIPTION
Add field description to the output voluptuous schema. This fixes a bug where MCP tool descriptions are omitted in Home Assistant.

https://github.com/home-assistant/core/issues/142598