### PR TITLE
Add support for anyOf and type: null

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,7 +4,12 @@ from typing import Any, TypeVar
 import pytest
 import voluptuous as vol
 
-from voluptuous_openapi import UNSUPPORTED, convert, convert_to_voluptuous, OpenApiVersion
+from voluptuous_openapi import (
+    UNSUPPORTED,
+    convert,
+    convert_to_voluptuous,
+    OpenApiVersion,
+)
 
 
 def test_int_schema():
@@ -344,7 +349,9 @@ def test_any_of():
     } == convert(vol.Any(vol.Maybe(float), vol.Maybe(int)))
     assert {
         "anyOf": [{"type": "null"}, {"type": "number"}, {"type": "integer"}],
-    } == convert(vol.Any(vol.Maybe(float), vol.Maybe(int)), openapi_version=OpenApiVersion.V3_1)
+    } == convert(
+        vol.Any(vol.Maybe(float), vol.Maybe(int)), openapi_version=OpenApiVersion.V3_1
+    )
 
 
 def test_all_of():

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -221,8 +221,10 @@ def test_fqdnurl():
 
 def test_maybe():
     assert {
-        "type": "string",
-        "nullable": True,
+        "anyOf": [
+            {"type": "null"},
+            {"type": "string"},
+        ],
     } == convert(vol.Schema(vol.Maybe(str)))
 
 
@@ -248,14 +250,10 @@ def test_constant():
     assert {"type": "integer", "enum": [1]} == convert(vol.Schema(1))
     assert {"type": "number", "enum": [1.5]} == convert(vol.Schema(1.5))
     assert {
-        "type": "object",
-        "nullable": True,
-        "description": "Must be null",
+        "type": "null",
     } == convert(vol.Schema(None))
     assert {
-        "type": "object",
-        "nullable": True,
-        "description": "Must be null",
+        "type": "null",
     } == convert(vol.Schema(type(None)))
 
 
@@ -324,8 +322,7 @@ def test_any_of():
     )
 
     assert {
-        "anyOf": [{"type": "number"}, {"type": "integer"}],
-        "nullable": True,
+        "anyOf": [{"type": "null"}, {"type": "number"}, {"type": "integer"}],
     } == convert(vol.Any(vol.Maybe(float), vol.Maybe(int)))
 
 
@@ -418,7 +415,7 @@ def test_function():
     def validator_nullable(data: float | None):
         return data
 
-    assert {"type": "number", "nullable": True} == convert(
+    assert {'anyOf': [{'type': 'number'}, {'type': 'null'}]} == convert(
         vol.Schema(validator_nullable)
     )
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -415,7 +415,7 @@ def test_function():
     def validator_nullable(data: float | None):
         return data
 
-    assert {'anyOf': [{'type': 'number'}, {'type': 'null'}]} == convert(
+    assert {"anyOf": [{"type": "number"}, {"type": "null"}]} == convert(
         vol.Schema(validator_nullable)
     )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,7 +17,7 @@ import openapi_schema_validator
 from typing import Any
 import logging
 
-from voluptuous_openapi import convert, convert_to_voluptuous
+from voluptuous_openapi import convert, convert_to_voluptuous, OpenApiVersion
 from jsonschema.exceptions import ValidationError
 
 
@@ -71,8 +71,9 @@ def generate_validators(
     yield openapi_validator(openapi_schema)
     yield voluptuous_validator(voluptuous_schema)
 
-    # Converted schema validations
-    yield openapi_validator(convert(voluptuous_schema))
+    # Converted schema validations. We use OpenAPI version 3.1 because it has equivalent
+    # semantics to voluptuous.
+    yield openapi_validator(convert(voluptuous_schema, openapi_version=OpenApiVersion.V3_1))
     yield voluptuous_validator(convert_to_voluptuous(openapi_schema))
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -463,7 +463,10 @@ def test_any_of_with_null(validator: Validator) -> None:
     generate_validators(
         {
             "type": "object",
-            "properties": {"id": {"type": "integer"}, "name": {"type": "string", "nullable": True}},
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string", "nullable": True},
+            },
             "required": ["id"],
         },
         vol.Schema({vol.Required("id"): int, vol.Optional("name"): str}),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -73,7 +73,9 @@ def generate_validators(
 
     # Converted schema validations. We use OpenAPI version 3.1 because it has equivalent
     # semantics to voluptuous.
-    yield openapi_validator(convert(voluptuous_schema, openapi_version=OpenApiVersion.V3_1))
+    yield openapi_validator(
+        convert(voluptuous_schema, openapi_version=OpenApiVersion.V3_1)
+    )
     yield voluptuous_validator(convert_to_voluptuous(openapi_schema))
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -352,7 +352,7 @@ def test_allow_extra(validator: Validator) -> None:
     ids=TEST_IDS,
 )
 def test_none(validator: Validator) -> None:
-    """Test float schema."""
+    """Test null or None values in the schema."""
 
     validator(None)
 

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -22,7 +22,6 @@ UNSUPPORTED = object()
 
 # These are not supported when converting from OpenAPI to voluptuous
 OPENAPI_UNSUPPORTED_KEYWORDS = {
-    "anyOf",
     "allOf",
     "multipleOf",
     "minItems",
@@ -208,11 +207,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
 
     if isinstance(schema, vol.Any):
         schema = schema.validators
-        if None in schema or NoneType in schema:
-            schema = [val for val in schema if val is not None and val is not NoneType]
-            nullable = True
-        else:
-            nullable = False
+        nullable = False
         if len(schema) == 1:
             result = convert(schema[0], custom_serializer=custom_serializer)
         else:
@@ -302,7 +297,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
         return {"type": TYPES_MAP[type(schema)], "enum": [schema]}
 
     if schema is None:
-        return {"type": "object", "nullable": True, "description": "Must be null"}
+        return {"type": "null"}
 
     if (
         get_origin(schema) is list
@@ -360,7 +355,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
                 return {"type": enum_type, "enum": enum_values, "nullable": True}
             return {"type": enum_type, "enum": enum_values}
         elif schema is NoneType:
-            return {"type": "object", "nullable": True, "description": "Must be null"}
+            return {"type": "null"}
 
     if schema is object:
         return {"type": "object", "additionalProperties": True}
@@ -398,10 +393,20 @@ def convert_to_voluptuous(schema: dict) -> vol.Schema:
     if (one_of := schema.get("oneOf")) is not None:
         if not isinstance(one_of, list):
             raise ValueError("Invalid schema, oneOf should be a list")
+        # This implements anyOf semantics sice it matches any of the subschemas,
+        # not just one of them.
         return vol.Any(*[convert_to_voluptuous(sub_schema) for sub_schema in one_of])
+
+    if (any_of := schema.get("anyOf")) is not None:
+        if not isinstance(any_of, list):
+            raise ValueError("Invalid schema, anyOf should be a list")
+        return vol.Any(*[convert_to_voluptuous(sub_schema) for sub_schema in any_of])
 
     if (schema_type := schema.get("type")) is None:
         raise ValueError("Invalid schema, missing type")
+
+    if schema["type"] == "null":
+        return vol.Schema(None)
 
     if (basic_type := TYPES_MAP_REV.get(schema_type)) is not None:
         if schema_type == "string":

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -32,7 +32,7 @@ OPENAPI_UNSUPPORTED_KEYWORDS = {
 
 class OpenApiVersion(StrEnum):
     """The OpenAPI version.
-    
+
     This is used to change the behavior when converting schemas to OpenAPI.
     """
 

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -51,7 +51,9 @@ def convert(
 
     def convert_with_args(schema: Any) -> dict:
         """Convert schema for recusing and propagating arguments."""
-        return convert(schema, custom_serializer=custom_serializer, openapi_version=openapi_version)
+        return convert(
+            schema, custom_serializer=custom_serializer, openapi_version=openapi_version
+        )
 
     def ensure_default(value: dict[str:Any]):
         """Make sure that type is set."""
@@ -228,7 +230,9 @@ def convert(
         schema = schema.validators
         # Infer the enum type based on the type of the first value, but default
         # to a string as a fallback.
-        if (None in schema or NoneType in schema) and openapi_version == OpenApiVersion.V3:
+        if (
+            None in schema or NoneType in schema
+        ) and openapi_version == OpenApiVersion.V3:
             schema = [val for val in schema if val is not None and val is not NoneType]
             nullable = True
         else:
@@ -236,9 +240,7 @@ def convert(
         if len(schema) == 1:
             result = convert_with_args(schema[0])
         else:
-            anyOf = [
-                convert_with_args(val) for val in schema
-            ]
+            anyOf = [convert_with_args(val) for val in schema]
 
             # Merge nested anyOf
             tmpAnyOf = []
@@ -341,9 +343,7 @@ def convert(
             }
         return {
             "type": "array",
-            "items": [
-                ensure_default(convert_with_args(s)) for s in schema.items()
-            ],
+            "items": [ensure_default(convert_with_args(s)) for s in schema.items()],
         }
 
     if schema in TYPES_MAP:


### PR DESCRIPTION
Add support for the `anyOf` openapi type. This also changes the behavior of nullable fields, prefering anyof  with a none type. The validation tests that exercise the combinations of schemas and converters has been updated to verify compatibility between openapi and voluptuous for these more specific scenarios.

Fixes here are meant to address report in https://github.com/home-assistant/core/issues/144300